### PR TITLE
Initial implementation of service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Manage an organization's scope of operation
+
+This service allows to manage the scope of operation (*nl. werkingsgebied*) for organizations.
+
+Note, this service is primarily developed to be used in the context of the [OrganizationPortal](https://github.com/lblod/app-organization-portal) application.
+
+## Installation
+Add the service in your project's `docker-compose.yml`:
+
+```yaml
+scope-of-operation:
+  image: lblod/scope-of-operation-service
+```

--- a/README.md
+++ b/README.md
@@ -11,3 +11,12 @@ Add the service in your project's `docker-compose.yml`:
 scope-of-operation:
   image: lblod/scope-of-operation-service
 ```
+
+## API
+### `GET /label-for-scope/:locationUuid`
+Get the label that should be displayed if the location resource with the provided UUID is use as an organisation's scope of operation.
+
+#### Response
+- `200 OK` The response body contains the requested label.
+- `404 No Content` No matching location resource or label was found.
+- `500 Internal Server Error` Something went wrong, check the service logs for more details.

--- a/README.md
+++ b/README.md
@@ -28,3 +28,22 @@ Get the UUIDs of all location resources that are contained with the location res
 - `200 OK` The response body contains a list of UUIDs of the contained location resources.
 - `404 No Content` No appropriate location resources were found.
 - `500 Internal Server Error` Something went wrong, check the service logs for more details.
+
+### `POST scope-for-locations`
+Create a location resource that contains exactly the locations specified in the body. If a suitable location resource already exists that will be reused instead of creating a new one.
+
+#### Body
+The body of the request should contain a list of the UUIDs for the location resources to be contained.
+
+```json
+{
+    data: {
+        locations: ["UUID1", "UUID2", ...]
+    }
+}
+```
+
+#### Response
+- `200 OK` An appropriate location resources already exists, and its UUID is in the body of the response.
+- `201 Created` An appropriate location resource was created, and its UUID is in the body of the response.
+- `500 Internal Server Error` Something went wrong, check the service logs for more details.

--- a/README.md
+++ b/README.md
@@ -20,3 +20,11 @@ Get the label that should be displayed if the location resource with the provide
 - `200 OK` The response body contains the requested label.
 - `404 No Content` No matching location resource or label was found.
 - `500 Internal Server Error` Something went wrong, check the service logs for more details.
+
+### `GET locations-in-scope/:locationUuid`
+Get the UUIDs of all location resources that are contained with the location resources identified by the provided UUID.
+
+#### Response
+- `200 OK` The response body contains a list of UUIDs of the contained location resources.
+- `404 No Content` No appropriate location resources were found.
+- `500 Internal Server Error` Something went wrong, check the service logs for more details.

--- a/app.js
+++ b/app.js
@@ -1,8 +1,77 @@
+import { app, errorHandler } from "mu";
+import {
+  getContainedLocations,
+  getLocationDetails,
+  getLocationUrisForUuids,
+} from "./lib/queries";
+import { getSortedLabels, requiresAggregateLabel } from "./lib/util";
 
-import { app, query, errorHandler } from 'mu';
+/** @import { LocationDetails } from "./lib/queries"; */
+
 app.get("/", function (_req, res) {
   res.send("Hello from scope-of-operation-service!");
 });
 
+app.get("/label-for-scope/:locationUuid", async function (req, res) {
+  try {
+    const locationUuid = req.params.locationUuid;
+    const location = await getLocationForUuid(locationUuid);
+
+    if (!location) {
+      return res.status(404).send();
+    }
+
+    let labelForScope;
+    if (requiresAggregateLabel(location)) {
+      const containedlocations = await getContainedLocations(location.uri);
+
+      labelForScope =
+        containedlocations.length > 0
+          ? getSortedLabels(...containedlocations)
+          : location.label;
+    } else {
+      labelForScope = location.label;
+    }
+
+    const statusCode = labelForScope ? 200 : 404;
+    return res.status(statusCode).json(labelForScope);
+  } catch (e) {
+    console.log("Something went wrong while retrieving the display label", e);
+    return res.status(500).send();
+  }
+});
+
+/**
+ * Get the location details for the location resource with the given UUID.
+ * @param {string} uuid - The UUID to search for.
+ * @returns {Promise<LocationDetails | undefined>} The details for the
+ *     identified location resource, undefined if the provided UUID does not
+ *     identify a location resource.
+ */
+async function getLocationForUuid(uuid) {
+  const location = await transformUuidsToLocationDetails(uuid);
+
+  return location && location.length > 0 ? location[0] : undefined;
+}
+
+/**
+ * Retrieve the details for a the location resources with the given uuids.
+ * @param {...string} uuids - The UUIDs for which to retrieve the location
+ *    details.
+ * @returns {Promise<LocationDetails[] | undefined>} The details for each
+ *    location resource for a UUID was provided. Undefined if no UUID was
+ *    provided or none of the provided ones identify a location resource.
+ */
+async function transformUuidsToLocationDetails(...uuids) {
+  if (uuids.length) {
+    // NOTE (03/06/2025): In the data different formats of URIs are use for
+    // location resources. Some location have a URI of the form
+    // `http://data.lblod.info/id/bestuurseenheden/UUID` instead of
+    // `http://data.lblod.info/id/werkingsgebieden/UUID`. Therefore, we cannot
+    // simply concatenate a prefix to the UUID to obtain the URI.
+    const uris = await getLocationUrisForUuids(...uuids);
+    return await getLocationDetails(...uris);
+  }
+}
 
 app.use(errorHandler);

--- a/app.js
+++ b/app.js
@@ -1,6 +1,6 @@
 
 import { app, query, errorHandler } from 'mu';
-app.get("/", function (req, res) {
+app.get("/", function (_req, res) {
   res.send("Hello from scope-of-operation-service!");
 });
 

--- a/config.js
+++ b/config.js
@@ -1,0 +1,14 @@
+export const PREFIX = {
+  besluit: "PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>",
+  ext: "PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>",
+  geo: "PREFIX geo: <http://www.opengis.net/ont/geosparql#>",
+  mu: "PREFIX mu: <http://mu.semte.ch/vocabularies/core/>",
+  prov: "PREFIX prov: <http://www.w3.org/ns/prov#>",
+  rdfs: "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>",
+};
+
+// NOTE (16/06/2025): We insert new location resources to the public graph as
+// this allows to keep all such resources to in a single graph. This simplifies
+// the configuration of other services using this data, such as the producers,
+// allows sharing location resources between modules.
+export const locationGraph = "http://mu.semte.ch/graphs/public";

--- a/config.js
+++ b/config.js
@@ -5,6 +5,7 @@ export const PREFIX = {
   mu: "PREFIX mu: <http://mu.semte.ch/vocabularies/core/>",
   prov: "PREFIX prov: <http://www.w3.org/ns/prov#>",
   rdfs: "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>",
+  dcterms: "PREFIX dcterms: <http://purl.org/dc/terms/>",
 };
 
 // NOTE (16/06/2025): We insert new location resources to the public graph as
@@ -12,3 +13,9 @@ export const PREFIX = {
 // the configuration of other services using this data, such as the producers,
 // allows sharing location resources between modules.
 export const locationGraph = "http://mu.semte.ch/graphs/public";
+
+// NOTE (16/06/2025): Used identify `prov:Location` resources created by this
+// service. This allows to easily differentiate "standard" locations that
+// already existed from the ad-hoc ones created by this service.
+export const creatorUri =
+  "http://lblod.data.gift/services/scope-of-operation-service";

--- a/lib/queries.js
+++ b/lib/queries.js
@@ -145,58 +145,73 @@ export async function getLocationUrisForUuids(...locations) {
 }
 
 /**
- * Retrieve the location matching containing the specified locations.
- * @param {...LocationDetails} locations - The locations to contain.
- * @returns {Promise<LocationDetails | null>} The details of the location
- *     containing the specified locations, null if none is found.
+ * Retrieve all locations that contain a specified  amount of locations.
+ * @param {number} amountOfContained - The amount of locations that should be
+ *     contained.
+ * @returns {Promise<LocationDetails[] | undefined>} The locations that contain
+ *     the right amount of locations.
  */
-export async function getMatchingLocation(...locations) {
-  const locationVariable = "?uri";
-
-  const sfWithinTriples = locations
-    .flatMap(
-      (location) =>
-        `${sparqlEscapeUri(location.uri)} geo:sfWithin ${locationVariable} .`,
-    )
-    .join("\n");
-
+export async function getMatchingLocationCandidates(amountOfContained) {
   const select = `
     ${PREFIX.prov}
+    ${PREFIX.mu}
     ${PREFIX.rdfs}
     ${PREFIX.ext}
     ${PREFIX.geo}
-    ${PREFIX.mu}
 
-    SELECT DISTINCT ${locationVariable} ?uuid ?label ?level
+    SELECT DISTINCT ?uri
     WHERE {
       GRAPH ${sparqlEscapeUri(locationGraph)} {
-        ${locationVariable} a prov:Location ;
-                  mu:uuid ?uuid ;
-                  rdfs:label ?label ;
-                  ext:werkingsgebiedNiveau ?level .
-
-        ${sfWithinTriples}
-
-        {
-          SELECT ${locationVariable} (COUNT(DISTINCT ?contained) AS ?noOfContained)
-          WHERE {
-            GRAPH ${sparqlEscapeUri(locationGraph)} {
-              ?contained geo:sfWithin ${locationVariable} .
-            }
+        ?uri a prov:Location .
+      }
+      {
+        SELECT ?uri (COUNT(DISTINCT ?contained) AS ?noOfContained)
+        WHERE {
+          GRAPH ${sparqlEscapeUri(locationGraph)} {
+            ?contained geo:sfWithin ?uri .
           }
         }
-        FILTER (?noOfContained = ${locations.length})
       }
-    }
-  `;
+      FILTER (?noOfContained = ${amountOfContained})
+    }`;
 
   const result = await query(select);
 
   if (result.results.bindings.length) {
-    return bindingToLocationObject(result.results.bindings[0]);
+    return result.results.bindings.flatMap((binding) => binding.uri.value);
   } else {
-    console.log("No location found that contains the specified locations.");
-    return null;
+    console.log(
+      "No location found with the right amount of contained locations.",
+    );
+  }
+}
+
+/**
+ * Retrieve the locations that are contained in the provided locations.
+ * @param {...string} location - The URI of the location for which the contained
+ *     ones should be listed.
+ * @returns {Promise<string[] | undefined>} The URIs of the contained locations.
+ */
+export async function listContainedLocations(location) {
+  const select = `
+    ${PREFIX.prov}
+    ${PREFIX.geo}
+
+    SELECT DISTINCT ?contained
+    WHERE {
+      GRAPH ${sparqlEscapeUri(locationGraph)} {
+        ?contained a prov:Location ;
+                   geo:sfWithin ${sparqlEscapeUri(location)}.
+      }
+    }`;
+
+  const result = await query(select);
+  if (result.results.bindings.length) {
+    return result.results.bindings.flatMap(
+      (binding) => binding.contained.value,
+    );
+  } else {
+    console.log("No contained locations found for ${location}");
   }
 }
 

--- a/lib/queries.js
+++ b/lib/queries.js
@@ -1,0 +1,144 @@
+import { sparqlEscapeString, sparqlEscapeUri, query } from "mu";
+import { locationGraph, PREFIX } from "../config";
+
+/**
+ * @typedef {object} LocationDetails
+ * @property {string} uri - The URI of the location resource.
+ * @property {string} uuid - The UUID of the location resource.
+ * @property {string} label - The label of the location resource.
+ * @property {string} level - The level of the location resource.
+ */
+
+/**
+ * Retrieve the locations that are within the provided location.
+ * @param {string} location - The URI of the containing location.
+ * @returns {Promise<LocationDetails[] | undefined>} The details of all
+ *     locations that are within the provided one.
+ */
+export async function getContainedLocations(location) {
+  const select = `
+    ${PREFIX.prov}
+    ${PREFIX.mu}
+    ${PREFIX.geo}
+    ${PREFIX.rdfs}
+    ${PREFIX.ext}
+
+    SELECT DISTINCT ?uri ?uuid ?label ?level
+    WHERE {
+    GRAPH ${sparqlEscapeUri(locationGraph)} {
+        ?uri a prov:Location ;
+             geo:sfWithin ${sparqlEscapeUri(location)} ;
+             mu:uuid ?uuid ;
+             rdfs:label ?label ;
+             ext:werkingsgebiedNiveau ?level .
+      }
+    }
+  `;
+
+  const result = await query(select);
+
+  if (result.results.bindings.length) {
+    return result.results.bindings.flatMap((binding) =>
+      bindingToLocationObject(binding),
+    );
+  } else {
+    console.log(`No locations found within ${location}`);
+  }
+}
+
+/**
+ * Retrieve the details for the provided location resources.
+ * @param {string[]} locations - The URIs of the required resources.
+ * @returns {Promise<LocationDetails[] | undefined>} The details for each found
+ *    location resource. Undefined if no URIs were provided or none of the
+ *    provided URIs identify a location resource.
+ */
+export async function getLocationDetails(...locations) {
+  const uriValues = locations.flatMap((uri) => sparqlEscapeUri(uri)).join("\n");
+
+  const select = `
+      ${PREFIX.prov}
+      ${PREFIX.mu}
+      ${PREFIX.ext}
+      ${PREFIX.rdfs}
+
+      SELECT DISTINCT ?uri ?uuid ?label ?level
+      WHERE {
+        GRAPH ${sparqlEscapeUri(locationGraph)} {
+          ?uri a prov:Location ;
+               mu:uuid ?uuid ;
+               rdfs:label ?label ;
+               ext:werkingsgebiedNiveau ?level .
+
+          VALUES ?uri {
+            ${uriValues}
+          }
+        }
+      }
+    `;
+
+  const result = await query(select);
+
+  if (result.results.bindings.length) {
+    return result.results.bindings.flatMap((binding) =>
+      bindingToLocationObject(binding),
+    );
+  } else {
+    console.log("No location resources found with the provided UUIDs");
+  }
+}
+
+/**
+ * Convert a binding resulting from a select query to a location details object.
+ * This requires that the provided binding has the necessary properties,
+ * otherwise an error will be thrown.
+ * @param {object} binding - An object that should contain the correct
+ *     properties.
+ * @returns {LocationDetails} A location details object containing the
+ *     corresponding values of the provided binding.
+ */
+function bindingToLocationObject(binding) {
+  return {
+    uri: binding.uri.value,
+    uuid: binding.uuid.value,
+    label: binding.label.value,
+    level: binding.level.value,
+  };
+}
+
+/**
+ * Find the URIs for the locations resources with the given UUIDs. Any UUID for
+ * which no corresponding location resource is found are ignored.
+ * @param {string[]} - The UUIDs to transform to URIs.
+ * @returns {Promise<string[] | undefined>} An array containing the URIs that
+ *     correspond to the provided UUIDs.
+ */
+export async function getLocationUrisForUuids(...locations) {
+  const uuidValues = locations
+    .flatMap((uuid) => sparqlEscapeString(uuid))
+    .join("\n");
+
+  const select = `
+      ${PREFIX.prov}
+      ${PREFIX.mu}
+
+      SELECT DISTINCT ?location
+      WHERE {
+        GRAPH ${sparqlEscapeUri(locationGraph)} {
+          ?location a prov:Location ;
+                    mu:uuid ?uuid .
+          VALUES ?uuid {
+            ${uuidValues}
+          }
+        }
+      }
+    `;
+
+  const result = await query(select);
+
+  if (result.results.bindings.length) {
+    return result.results.bindings.flatMap((binding) => binding.location.value);
+  } else {
+    console.log("No location resources found for the provided UUIDs.");
+  }
+}

--- a/lib/queries.js
+++ b/lib/queries.js
@@ -1,4 +1,5 @@
-import { sparqlEscapeString, sparqlEscapeUri, query } from "mu";
+import { sparqlEscapeString, sparqlEscapeUri, uuid, query } from "mu";
+import { updateSudo } from "@lblod/mu-auth-sudo";
 import { locationGraph, PREFIX } from "../config";
 
 /**
@@ -141,4 +142,120 @@ export async function getLocationUrisForUuids(...locations) {
   } else {
     console.log("No location resources found for the provided UUIDs.");
   }
+}
+
+/**
+ * Retrieve the location matching containing the specified locations.
+ * @param {...LocationDetails} locations - The locations to contain.
+ * @returns {Promise<LocationDetails | null>} The details of the location
+ *     containing the specified locations, null if none is found.
+ */
+export async function getMatchingLocation(...locations) {
+  const locationVariable = "?uri";
+
+  const sfWithinTriples = locations
+    .flatMap(
+      (location) =>
+        `${sparqlEscapeUri(location.uri)} geo:sfWithin ${locationVariable} .`,
+    )
+    .join("\n");
+
+  const select = `
+    ${PREFIX.prov}
+    ${PREFIX.rdfs}
+    ${PREFIX.ext}
+    ${PREFIX.geo}
+    ${PREFIX.mu}
+
+    SELECT DISTINCT ${locationVariable} ?uuid ?label ?level
+    WHERE {
+      GRAPH ${sparqlEscapeUri(locationGraph)} {
+        ${locationVariable} a prov:Location ;
+                  mu:uuid ?uuid ;
+                  rdfs:label ?label ;
+                  ext:werkingsgebiedNiveau ?level .
+
+        ${sfWithinTriples}
+
+        {
+          SELECT ${locationVariable} (COUNT(DISTINCT ?contained) AS ?noOfContained)
+          WHERE {
+            GRAPH ${sparqlEscapeUri(locationGraph)} {
+              ?contained geo:sfWithin ${locationVariable} .
+            }
+          }
+        }
+        FILTER (?noOfContained = ${locations.length})
+      }
+    }
+  `;
+
+  const result = await query(select);
+
+  if (result.results.bindings.length) {
+    return bindingToLocationObject(result.results.bindings[0]);
+  } else {
+    console.log("No location found that contains the specified locations.");
+    return null;
+  }
+}
+
+/**
+ * Insert a new location resource with the given label and level into the
+ * specified graph.
+ * @param {string} label - The value that should be inserted as label for the
+ *   new location.
+ * @param {string} level - The label for the level of the new location.
+ * @returns {Promise<LocationDetails>} The details of the new location resource.
+ */
+export async function insertLocationResource(label, level) {
+  const locationUuid = uuid();
+  const locationUri = `http://data.lblod.info/id/werkingsgebieden/${locationUuid}`;
+
+  const insert = `
+    ${PREFIX.prov}
+    ${PREFIX.mu}
+    ${PREFIX.ext}
+    ${PREFIX.rdfs}
+
+    INSERT DATA {
+      GRAPH ${sparqlEscapeUri(locationGraph)} {
+        ${sparqlEscapeUri(locationUri)} a prov:Location ;
+          mu:uuid ${sparqlEscapeString(locationUuid)} ;
+          rdfs:label ${sparqlEscapeString(label)} ;
+          ext:werkingsgebiedNiveau ${sparqlEscapeString(level)} .
+      }
+    }
+  `;
+
+  await updateSudo(insert);
+
+  return { uri: locationUri, uuid: locationUuid, label: label, level: level };
+}
+
+/**
+ * Link a given location to the locations it contains.
+ * @param {string} location - The URI of the containing location.
+ * @param {...string} containedLocations - The URIs of the contained locations.
+ */
+export async function linkContainedLocations(location, ...containedLocations) {
+  const sfWithinTriples = containedLocations
+    .flatMap((loc) => createSfWithinTriple(loc, location))
+    .join("\n");
+
+  const insert = `
+    ${PREFIX.geo}
+
+    INSERT DATA {
+      GRAPH ${sparqlEscapeUri(locationGraph)} {
+        ${sfWithinTriples}
+      }
+    }
+  `;
+
+  await updateSudo(insert);
+}
+
+function createSfWithinTriple(subject, object) {
+  return `${sparqlEscapeUri(subject)} geo:sfWithin ${sparqlEscapeUri(object)} .`;
 }

--- a/lib/queries.js
+++ b/lib/queries.js
@@ -1,6 +1,6 @@
 import { sparqlEscapeString, sparqlEscapeUri, uuid, query } from "mu";
 import { updateSudo } from "@lblod/mu-auth-sudo";
-import { locationGraph, PREFIX } from "../config";
+import { creatorUri, locationGraph, PREFIX } from "../config";
 
 /**
  * @typedef {object} LocationDetails
@@ -232,13 +232,15 @@ export async function insertLocationResource(label, level) {
     ${PREFIX.mu}
     ${PREFIX.ext}
     ${PREFIX.rdfs}
+    ${PREFIX.dcterms}
 
     INSERT DATA {
       GRAPH ${sparqlEscapeUri(locationGraph)} {
         ${sparqlEscapeUri(locationUri)} a prov:Location ;
           mu:uuid ${sparqlEscapeString(locationUuid)} ;
           rdfs:label ${sparqlEscapeString(label)} ;
-          ext:werkingsgebiedNiveau ${sparqlEscapeString(level)} .
+          ext:werkingsgebiedNiveau ${sparqlEscapeString(level)} ;
+          dcterms:creator ${sparqlEscapeUri(creatorUri)} .
       }
     }
   `;

--- a/lib/util.js
+++ b/lib/util.js
@@ -5,11 +5,16 @@ export const LOCATION_LEVELS = {
   municipality: "Gemeente",
   referenceRegion: "Referentieregio",
   province: "Provincie",
+  composedScope: "Samengesteld werkingsgebied",
 };
 
 /**
  * Check whether a location's label needs to be the aggregation of the its
  * contained locations.
+ * Note, the label of a location that is created by this service is already set
+ * to the aggregate of the labels of its contained locations. This label can
+ * used as is, and thus for such locations it is not necessary to aggregate the
+ * labels on the fly.
  * @param {LocationDetails} location - The location that needs to be checked.
  * @returns {boolean} True if the location is a province or reference region.
  */

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,37 @@
+/** @import { LocationDetails } from "./lib/queries"; */
+
+export const LOCATION_LEVELS = {
+  district: "District",
+  municipality: "Gemeente",
+  referenceRegion: "Referentieregio",
+  province: "Provincie",
+};
+
+/**
+ * Check whether a location's label needs to be the aggregation of the its
+ * contained locations.
+ * @param {LocationDetails} location - The location that needs to be checked.
+ * @returns {boolean} True if the location is a province or reference region.
+ */
+export function requiresAggregateLabel(location) {
+  return (
+    location.level === LOCATION_LEVELS.referenceRegion ||
+    location.level === LOCATION_LEVELS.province
+  );
+}
+
+/**
+ * Construct a string containing labels of the provided locations in
+ * alphabetical order.
+ * @param {...LocationDetails} locations - The details for at least one
+ *     location.
+ * @returns {string} The concatenation of all labels of the provided locations.
+ */
+export function getSortedLabels(...locations) {
+  return locations.length
+    ? locations
+        .flatMap((location) => location.label)
+        .sort((a, b) => a.localeCompare(b, "nl"))
+        .join(", ")
+    : null;
+}

--- a/lib/util.js
+++ b/lib/util.js
@@ -40,3 +40,18 @@ export function getSortedLabels(...locations) {
         .join(", ")
     : null;
 }
+
+/**
+ * Check whether two arrays contain the same elements, ignoring any difference
+ * in order. This uses same-value-zero equality to compare the elements of the
+ * arrays.
+ * @param {any[]} left - an array
+ * @param {any[]} right - another array
+ * @returns {boolean} True if the provided arrays contain the same elements,
+ *     false otherwise.
+ */
+export function containSameElements(left, right) {
+  const a = left.every((e) => right.includes(e));
+  const b = right.every((e) => left.includes(e));
+  return a && b;
+}


### PR DESCRIPTION
This service provides functionality to manage the location resources that can be used scope of operation (*nl. werkingsgebied*) for administrative units. Due to constraints in the data model[^1] an administrative unit can only be linked to at most 1 location as its scope of operation. Consequently, an appropriate location resource may have to be created whenever an administrative unit is assigned multiple locations as its scope of operation.

In summary this service provides three functions
1. Determine the label that should be shown in the user for a given location. This is either simply the label directly linked to the location resource or a concatenation of the labels for all locations contained in the given one.
2. Determine all location resources that are contained within a given one.
3. Find or, if necessary, create a location resource that contains a given set of other location resources.

## Points of discussion
### Level for new location resources
In OP location resources have a level[^2], the currently existing locations have as values "District", "Gemeente", "Referentieregio", or "Province". It remains to be determined what level a newly created location resource should receive. The question was put to business but they had no opinion on it.

Note, that reusing any of the existing levels likely impacts the current implementation of this service. For example, the expected functionality is to show users a list of municipality-level locations as a unit's scope of operation. Therefore, for units linked with a "Referentieregio" level location, this service looks for the contained locations and uses their labels instead of the label of the directly linked location resource.

### Writing to public graph
In preparation of this functionality all location data was moved to the public graph, see [#542](https://github.com/lblod/app-organization-portal/pull/542). Therefore, this service also writes any newly created location resources to the `public` graph. This has the advantage that it keeps all location data in a single graph. This avoids additional complexity in the configuration of other services such as the producers and authorisation layer.

## Notes
- As part of the MVP locations at the "District" level are ignored. They are only relevant for the municipality of Antwerp and may be included in a later version.

## Related PRs
- Backend: [#550](https://github.com/lblod/app-organization-portal/pull/550)
- Frontend: [#680](https://github.com/lblod/frontend-organization-portal/pull/680)

## Related tickets
- OP-3205

[^1]: See the definition of an [administrative unit](https://data.vlaanderen.be/doc/applicatieprofiel/besluit-publicatie/#Bestuurseenheid) in the Besluit application profile.
[^2]: Using the self-defined predicate `<http://mu.semte.ch/vocabularies/ext/werkingsgebiedNiveau>`