### PR TITLE
fix: allow to request locations contained in a district-level scopes of operation

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,6 +11,7 @@ import {
 import {
   containSameElements,
   getSortedLabels,
+  isUndividableLocation,
   LOCATION_LEVELS,
   requiresAggregateLabel,
 } from "./lib/util";
@@ -60,8 +61,7 @@ app.get("/locations-in-scope/:locationUuid", async function (req, res) {
     }
 
     let locations = [];
-    // TODO: Should also consider districts, but they are ignored in the MVP
-    if (location.level === LOCATION_LEVELS.municipality) {
+    if (isUndividableLocation(location)) {
       locations.push(location.uuid);
     } else {
       const containedLocations = await getContainedLocations(location.uri);

--- a/lib/util.js
+++ b/lib/util.js
@@ -9,6 +9,24 @@ export const LOCATION_LEVELS = {
 };
 
 /**
+ * Check whether a location can be divided into contained lower-level locations.
+ * @param {LocationDetails} location - The location that needs to be checked.
+ * @returns {boolean} True if the provided location is a municipality or
+ *    district that cannot be further divided, false otherwise.
+ */
+export function isUndividableLocation(location) {
+  // NOTE (29/07/2025): In the MVP for the scope of operation functionality we
+  // opted to mostly ignore district-level locations, allowing users only to
+  // select municipality-level locations.  But we do include the district-level
+  // locations here so that such they can be correctly displayed as scopes of
+  // operation for the actual district organisations.
+  return (
+    location.level === LOCATION_LEVELS.municipality ||
+    location.level === LOCATION_LEVELS.district
+  );
+}
+
+/**
  * Check whether a location's label needs to be the aggregation of the its
  * contained locations.
  * Note, the label of a location that is created by this service is already set


### PR DESCRIPTION
While district-level scopes of operation are largely ignored in the MVP for the edit scope of operation functionality, OP does contain some organisations whose scope of operation is at that level. Namely districts themselves.

This change ensures the service can correctly respond to requests for the locations in a district-level scope of operation. Just as with municipality-level scopes of operation it will simply reply with the location itself. In other words, both municipality and district-level scopes of operation are considered to be undividable.

## How to test
0. Configure your OP stack to use a locally built version of this service.
1. Log in as a non-worship editor.
2. Find a district type organisation in the organisations overview table, you can filter by type in the sidebar. When using DEV data, it is best to select an actually existing district (Antwerpen, Borgerhout, Merksem, etc.) as these have their scope of operation correctly set. Most districts created by (automated) testing do not have a scope of operation set.
3. On the core data page for the district, click the edit button in the top right corner.
4. In the edit form a value should be shown in the scope of operation input field. Typically the displayed label is the same as the name of the selected district.

## Notes
Together with [#686](https://github.com/lblod/frontend-organization-portal/pull/686) for the frontend this PR is intended to fix the bug reported in the linked ticket. To test whether it solves the reported bug:

0. Launch a local frontend for the branch in the linked PR in addition to the locally built version of this service.
1. Log in as a non-worship editor.
2. Find a district type organisation in the organisations overview table, you can filter by type in the sidebar.
3. For districts with a scope of operation (*nl. Werkingsgebied*)set in their core data page:
   - the same scope of operation should be visible on the edit form of that page (the bug was that the scope of operation disappeared); and
   - the scope of operation should **not** be editable.
   For districts for which no scope of operation is set:
   - the scope of operations field should be empty on both the view and edit page; and
   - the scope of operation should **not** be editable.

## Related tickets
- OP-3647